### PR TITLE
Add ArcheoRAG demo UI

### DIFF
--- a/archeorag/README.md
+++ b/archeorag/README.md
@@ -1,0 +1,49 @@
+# ArcheoRAG UI
+
+This folder contains a simple Streamlit application that uses
+[PaperQA2](https://github.com/Future-House/paper-qa) to query your
+personal PDF library.
+
+The app supports different settings profiles such as `fast` or
+`contracrow` (for contradiction detection). It can be extended with the
+helpers in `paperqa.contrib` to download open‑access papers from sources
+like OpenReview or Zotero.
+
+## Requirements
+
+- Python 3.11+
+- `streamlit`
+- `paper-qa`
+
+Install the dependencies:
+
+```bash
+pip install streamlit paper-qa
+```
+
+Set your LLM API key (e.g. `OPENAI_API_KEY`) before running the app.
+
+## Usage
+
+From the repository root run:
+
+```bash
+streamlit run archeorag/app.py
+```
+
+Upload PDFs, select a settings profile and ask questions about your
+library.
+
+## Optional: fetch papers automatically
+
+You can fetch open‑access papers with the included helpers. For
+instance, to download relevant submissions from an OpenReview venue:
+
+```python
+from paperqa import Settings
+from paperqa.contrib.openreview_paper_helper import OpenReviewPaperHelper
+
+helper = OpenReviewPaperHelper(Settings.from_name("openreview"), venue_id="ICLR.cc/2025/Conference")
+submissions = helper.fetch_relevant_papers("bronze age pottery")
+await helper.aadd_docs(submissions, docs)
+```

--- a/archeorag/README.md
+++ b/archeorag/README.md
@@ -21,7 +21,9 @@ Install the dependencies:
 pip install streamlit paper-qa
 ```
 
-Set your LLM API key (e.g. `OPENAI_API_KEY`) before running the app.
+You need an LLM API key (e.g. `OPENAI_API_KEY`).
+You can either export it before running the app or enter it in the UI
+sidebar after launch.
 
 ## Usage
 

--- a/archeorag/app.py
+++ b/archeorag/app.py
@@ -1,0 +1,38 @@
+import asyncio
+from pathlib import Path
+
+import streamlit as st
+from paperqa import Docs, Settings, agent_query
+
+st.title("ArcheoRAG")
+
+if "docs" not in st.session_state:
+    st.session_state.docs = Docs(name="archeorag")
+
+setting_name = st.selectbox(
+    "Settings profile",
+    ["default", "fast", "high_quality", "wikicrow", "contracrow"],
+)
+
+if setting_name == "default":
+    settings = Settings()
+else:
+    settings = Settings.from_name(setting_name)
+
+upload_dir = Path("archeorag/uploads")
+upload_dir.mkdir(parents=True, exist_ok=True)
+
+files = st.file_uploader("Upload PDFs", type="pdf", accept_multiple_files=True)
+if files:
+    for file in files:
+        file_path = upload_dir / file.name
+        file_path.write_bytes(file.read())
+        asyncio.run(st.session_state.docs.aadd(file_path, docname=file.name))
+        st.success(f"Added {file.name}")
+
+question = st.text_input("Ask a question about your papers")
+if st.button("Submit") and question:
+    response = asyncio.run(
+        agent_query(question, settings, docs=st.session_state.docs)
+    )
+    st.markdown(response.session.formatted_answer)

--- a/archeorag/app.py
+++ b/archeorag/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from pathlib import Path
 
 import streamlit as st
@@ -8,6 +9,13 @@ st.title("ArcheoRAG")
 
 if "docs" not in st.session_state:
     st.session_state.docs = Docs(name="archeorag")
+
+st.sidebar.header("LLM API")
+api_key = st.sidebar.text_input("OpenAI API key", type="password")
+if st.sidebar.button("Save key") and api_key:
+    os.environ["OPENAI_API_KEY"] = api_key
+    st.session_state["api_key"] = api_key
+    st.sidebar.success("API key saved in session")
 
 setting_name = st.selectbox(
     "Settings profile",


### PR DESCRIPTION
## Summary
- create `archeorag/` folder
- add a simple Streamlit app to explore PaperQA2 locally
- document how to run the new ArcheoRAG demo and fetch papers from OpenReview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684c754a30e48329ae40780f8b2ea50f